### PR TITLE
crate: update sbi-rt to released version 0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,15 +401,17 @@ dependencies = [
 [[package]]
 name = "sbi-rt"
 version = "0.0.1"
-source = "git+https://github.com/rustsbi/sbi-rt?branch=dev#bbabc67b7a613ce1f75cde8610b31335457f15a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f27f053b4d773f8027cd703baed9764f730a058006da4947522394515afe8c"
 dependencies = [
  "sbi-spec",
 ]
 
 [[package]]
 name = "sbi-spec"
-version = "0.0.2"
-source = "git+https://github.com/rustsbi/sbi-spec.git?branch=dev#54a6bad86582b275f0ef0d49c771067cb7518bdd"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab331a5c9852a6587ea9fc74bdda950d7dfc7076aa791434d45cbc2001ba5c7c"
 dependencies = [
  "static_assertions",
 ]

--- a/ch1-lab/Cargo.toml
+++ b/ch1-lab/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 
 [dependencies]
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"
 console = { path = "../console" }

--- a/ch1/Cargo.toml
+++ b/ch1/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 
 [dependencies]
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"

--- a/ch2/Cargo.toml
+++ b/ch2/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 
 [dependencies]
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"
 riscv = "0.8.0"
 
 linker = { path = "../linker" }

--- a/ch3/Cargo.toml
+++ b/ch3/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 
 [dependencies]
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"
 riscv = "0.8.0"
 
 linker = { path = "../linker" }

--- a/ch4/Cargo.toml
+++ b/ch4/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 
 [dependencies]
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"
 customizable-buddy = "0.0.2"
 xmas-elf = "0.8.0"
 riscv = "0.8.0"

--- a/ch5/Cargo.toml
+++ b/ch5/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["zflcs <1491657576@qq.com>"]
 
 [dependencies]
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"
 customizable-buddy = "0.0.2"
 xmas-elf = "0.8.0"
 riscv = "0.8.0"

--- a/ch6/Cargo.toml
+++ b/ch6/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["tkf2019 <kaifu6821@qq.com>"]
 
 [dependencies]
 virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers", rev = "4ee80e5" }
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"
 customizable-buddy = "0.0.2"
 xmas-elf = "0.8.0"
 riscv = "0.8.0"

--- a/ch7/Cargo.toml
+++ b/ch7/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["scPointer <jax01@foxmail.com>"]
 
 [dependencies]
 virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers", rev = "4ee80e5" }
-sbi-rt = { git = "https://github.com/rustsbi/sbi-rt", branch = "dev" }
+sbi-rt = "0.0.1"
 customizable-buddy = "0.0.2"
 xmas-elf = "0.8.0"
 riscv = "0.8.0"


### PR DESCRIPTION
把sbi-rt依赖库更新到已经发布的0.0.1版本，避免编译时需要从github仓库下载文件。